### PR TITLE
Remove missed activesupport dependency

### DIFF
--- a/lib/smart_enum.rb
+++ b/lib/smart_enum.rb
@@ -3,6 +3,7 @@
 require "smart_enum/version"
 require "smart_enum/associations"
 require "smart_enum/attributes"
+require "smart_enum/utilities"
 
 # A class used to build in-memory graphs of "lookup" objects that are
 # long-lived and can associate among themselves or ActiveRecord instances.
@@ -118,7 +119,7 @@ class SmartEnum
 
   def self.register_values(values, enum_type=self, detect_sti_types: false)
     values.each do |raw_attrs|
-      _deferred_attr_hashes << raw_attrs.symbolize_keys.merge(enum_type: enum_type, detect_sti_types: detect_sti_types)
+      _deferred_attr_hashes << SmartEnum::Utilities.symbolize_hash_keys(raw_attrs).merge(enum_type: enum_type, detect_sti_types: detect_sti_types)
     end
     @_deferred_values_present = true
   end

--- a/lib/smart_enum/attributes.rb
+++ b/lib/smart_enum/attributes.rb
@@ -79,7 +79,7 @@ class SmartEnum
       if block_given?
         fail "Block passed, but it would be ignored"
       end
-      init_opts = opts.symbolize_keys
+      init_opts = ::SmartEnum::Utilities.symbolize_hash_keys(opts)
       if self.class.attribute_set.empty?
         fail "no attributes defined for #{self.class}"
       end

--- a/lib/smart_enum/utilities.rb
+++ b/lib/smart_enum/utilities.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SmartEnum
+  module Utilities
+    def self.symbolize_hash_keys(original_hash)
+      return original_hash if original_hash.each_key.all?(Symbol)
+      symbolized_hash = {}
+      original_hash.each_key do |key|
+        symbolized_hash[key.to_sym] = original_hash[key]
+      end
+      symbolized_hash
+    end
+  end
+end

--- a/lib/smart_enum/utilities.rb
+++ b/lib/smart_enum/utilities.rb
@@ -3,7 +3,7 @@
 class SmartEnum
   module Utilities
     def self.symbolize_hash_keys(original_hash)
-      return original_hash if original_hash.each_key.all?(Symbol)
+      return original_hash if original_hash.each_key.all?{|key| Symbol === key }
       symbolized_hash = {}
       original_hash.each_key do |key|
         symbolized_hash[key.to_sym] = original_hash[key]


### PR DESCRIPTION
Despite having removed our activesupport requires in dfded7066e527cbb6a249125182e9156a4abcaab and b271dea684b6be0c45781f075cf040c2ef2601e7, we were still unknowingly depending on AS `Hash#symbolize_keys` in two places.  I've included an implementation that does not monkeypatch the Hash class.

The reason the test suite didn't catch this is that we require activerecord in the test suite in order to test the AR compatibility libs, so all of our tests were running with *all* activesupport monkeypatches.  I will separately split up the test suite to fix this issue.
