### PR TITLE
More activesupport removal

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,9 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec_noar) { |t| t.exclude_pattern = "spec/active_record_compatibility_spec.rb" }
+RSpec::Core::RakeTask.new(:spec_ar) { |t| t.pattern = "spec/active_record_compatibility_spec.rb" }
+
+task spec: [:spec_noar, :spec_ar]
 
 task :default => :spec

--- a/lib/smart_enum.rb
+++ b/lib/smart_enum.rb
@@ -132,7 +132,7 @@ class SmartEnum
     fail EnumLocked.new(enum_type) if enum_locked?
     type_attr_val = attrs[DEFAULT_TYPE_ATTR_STR] || attrs[DEFAULT_TYPE_ATTR_SYM]
     klass = if type_attr_val && detect_sti_types
-              _constantize_cache[type_attr_val] ||= type_attr_val.constantize
+              _constantize_cache[type_attr_val] ||= SmartEnum::Utilities.constantize(type_attr_val)
             else
               enum_type
             end

--- a/lib/smart_enum/active_record_compatibility.rb
+++ b/lib/smart_enum/active_record_compatibility.rb
@@ -115,7 +115,7 @@ class SmartEnum
       #   find_by(id: '1', key: :blah)
       # even when types differ like we can in ActiveRecord.
       def cast_query_attrs(raw_attrs)
-        raw_attrs.symbolize_keys.each_with_object({}) do |(k, v), new_attrs|
+        SmartEnum::Utilities.symbolize_hash_keys(raw_attrs).each_with_object({}) do |(k, v), new_attrs|
           if v.instance_of?(Array)
             fail "SmartEnum can't query with array arguments yet.  Got #{raw_attrs.inspect}"
           end

--- a/lib/smart_enum/associations.rb
+++ b/lib/smart_enum/associations.rb
@@ -40,7 +40,10 @@ class SmartEnum
       enum_associations[association_name] = association
 
       define_method(association_name) do
-        public_send(association.through_association).try(association.association_method)
+        intermediate = public_send(association.through_association)
+        if intermediate
+          intermediate.public_send(association.association_method)
+        end
       end
     end
 

--- a/lib/smart_enum/associations.rb
+++ b/lib/smart_enum/associations.rb
@@ -80,7 +80,7 @@ class SmartEnum
 
       if generate_writer
         define_method("#{association_name}=") do |value|
-          self.public_send(fk_writer_name, value.try(:id))
+          self.public_send(fk_writer_name, value&.id)
         end
       end
     end

--- a/lib/smart_enum/associations.rb
+++ b/lib/smart_enum/associations.rb
@@ -108,7 +108,7 @@ class SmartEnum
       end
 
       def foreign_key
-        @foreign_key ||= (foreign_key_option || association_name.to_s.foreign_key).to_sym
+        @foreign_key ||= (foreign_key_option || SmartEnum::Utilities.foreign_key(association_name)).to_sym
       end
 
       def generated_method_name
@@ -128,7 +128,7 @@ class SmartEnum
           begin
             return foreign_key_option.to_sym if foreign_key_option
             if owner_class.name
-              owner_class.name.foreign_key.to_sym
+              SmartEnum::Utilities.foreign_key(owner_class.name).to_sym
             else
               raise "You must specify the foreign_key option when using a 'has_*' association on an anoymous class"
             end

--- a/lib/smart_enum/associations.rb
+++ b/lib/smart_enum/associations.rb
@@ -104,7 +104,7 @@ class SmartEnum
       end
 
       def class_name
-        @class_name ||= (class_name_option || association_name.to_s.classify).to_s
+        @class_name ||= (class_name_option || SmartEnum::Utilities.classify(association_name)).to_s
       end
 
       def foreign_key

--- a/lib/smart_enum/associations.rb
+++ b/lib/smart_enum/associations.rb
@@ -116,7 +116,7 @@ class SmartEnum
       end
 
       def association_class
-        @association_class ||= class_name.constantize.tap{|klass|
+        @association_class ||= SmartEnum::Utilities.constantize(class_name).tap{|klass|
           ::SmartEnum::Associations.__assert_enum(klass)
         }
       end

--- a/lib/smart_enum/utilities.rb
+++ b/lib/smart_enum/utilities.rb
@@ -10,5 +10,13 @@ class SmartEnum
       end
       symbolized_hash
     end
+
+    def self.foreign_key(string)
+      singularize(string) + "_id"
+    end
+
+    def self.singularize(string)
+      string.to_s.chomp("s")
+    end
   end
 end

--- a/lib/smart_enum/utilities.rb
+++ b/lib/smart_enum/utilities.rb
@@ -23,6 +23,18 @@ class SmartEnum
       underscore(string) + "s"
     end
 
+    def self.classify(string)
+      singularize(camelize(string))
+    end
+
+    # Convert snake case string to camelcase string.
+    # Adapted from https://github.com/jeremyevans/sequel/blob/5.10.0/lib/sequel/model/inflections.rb#L103
+    def self.camelize(string)
+      string.to_s
+        .gsub(/\/(.?)/){|x| "::#{x[-1..-1].upcase unless x == '/'}"}
+        .gsub(/(^|_)(.)/){|x| x[-1..-1].upcase}
+    end
+
     # Adapted from
     # https://github.com/jeremyevans/sequel/blob/5.10.0/lib/sequel/model/inflections.rb#L147-L148
     def self.underscore(string)

--- a/lib/smart_enum/utilities.rb
+++ b/lib/smart_enum/utilities.rb
@@ -12,11 +12,27 @@ class SmartEnum
     end
 
     def self.foreign_key(string)
-      singularize(string) + "_id"
+      singularize(tableize(string)) + "_id"
     end
 
     def self.singularize(string)
       string.to_s.chomp("s")
+    end
+
+    def self.tableize(string)
+      underscore(string) + "s"
+    end
+
+    # Adapted from
+    # https://github.com/jeremyevans/sequel/blob/5.10.0/lib/sequel/model/inflections.rb#L147-L148
+    def self.underscore(string)
+      string
+        .to_s
+        .gsub(/::/, '/')
+        .gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+        .gsub(/([a-z\d])([A-Z])/,'\1_\2')
+        .tr("-", "_")
+        .downcase
     end
   end
 end

--- a/lib/smart_enum/utilities.rb
+++ b/lib/smart_enum/utilities.rb
@@ -11,6 +11,10 @@ class SmartEnum
       symbolized_hash
     end
 
+    def self.constantize(string)
+      Object.const_get(string)
+    end
+
     def self.foreign_key(string)
       singularize(tableize(string)) + "_id"
     end

--- a/lib/smart_enum/yaml_store.rb
+++ b/lib/smart_enum/yaml_store.rb
@@ -12,7 +12,7 @@ class SmartEnum
         raise "Cannot infer data file for anonymous class"
       end
 
-      filename = "#{self.name.tableize}.yml"
+      filename = "#{SmartEnum::Utilities.tableize(self.name)}.yml"
       file_path = File.join(SmartEnum::YamlStore.data_root, filename)
       values = YAML.load_file(file_path)
       register_values(values, self, detect_sti_types: true)

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe SmartEnum::Utilities do
+  describe '.symbolize_hash_keys' do
+    subject(:symbolized) { ->input { SmartEnum::Utilities.symbolize_hash_keys(input) } }
+    it 'changes root keys from strings to symbols' do
+      input = { "foo" => "bar", "baz" => "qux" }
+      expect(symbolized.(input)).to eq(foo: "bar", baz: "qux")
+    end
+
+    it 'it saves allocations by returning the same object if all keys are already symbols' do
+      input = { :foo => "bar", :baz => "qux" }
+      expect(symbolized.(input).object_id).to eq(input.object_id)
+    end
+  end
+
+  describe '.foreign_key' do
+    subject(:foreign_key) { ->input { SmartEnum::Utilities.foreign_key(input) } }
+
+    it 'converts camelcase strings to foreign-key-style' do
+      expect(foreign_key.('MyClassName')).to eq('my_class_name_id')
+    end
+
+    it 'converts snake case strings to foreign-key-style' do
+      expect(foreign_key.('some_thing')).to eq('some_thing_id')
+    end
+  end
+
+  describe '.singularize' do
+    subject(:singularize) { ->input { SmartEnum::Utilities.singularize(input) } }
+
+    it 'strips an s from strings' do
+      expect(singularize.('widgets')).to eq('widget')
+    end
+
+    it 'does nothing with no s' do
+      expect(singularize.('widget')).to eq('widget')
+    end
+  end
+
+  describe '.tableize' do
+    subject(:tableize) { ->input { SmartEnum::Utilities.tableize(input) } }
+
+    it 'converts singular camelcase strings to the equivalent table name' do
+      expect(tableize.('FooBar')).to eq('foo_bars')
+    end
+
+    it 'converts singular underscore strings to the equivalent table name' do
+      expect(tableize.('baz_bar')).to eq('baz_bars')
+    end
+  end
+
+  describe '.classify' do
+    subject(:classify) { ->input { SmartEnum::Utilities.classify(input) } }
+
+    it 'converts table-style strings to camelcase class-style' do
+      expect(classify.('some_things')).to eq('SomeThing')
+    end
+
+    it 'converts singular underscore strings to camelcase class-style' do
+      expect(classify.('foo_bar')).to eq('FooBar')
+    end
+  end
+
+  describe '.camelize' do
+    subject(:camelize) { ->input { SmartEnum::Utilities.camelize(input) } }
+
+    it 'converts underscore text to camelcase' do
+      expect(camelize.('some_things')).to eq('SomeThings')
+    end
+  end
+
+  describe '.underscore' do
+    subject(:underscore) { ->input { SmartEnum::Utilities.underscore(input) } }
+
+    it 'converts to underscore' do
+      expect(underscore.('FooModule::BarClass')).to eq('foo_module/bar_class')
+    end
+  end
+end


### PR DESCRIPTION
This [implements](https://github.com/ShippingEasy/smart_enum/commit/0f0b2b2cc56109e83f590dac6c77cf71cfa0fa69) the test suite splitting mentioned in https://github.com/ShippingEasy/smart_enum/pull/2 to ensure that activesupport/activerecord is not loaded when running most of the test suite.

Once that was in place it became clear from the failing tests that I had failed to catch a number of activesupport methods in my previous attempts to remove that library.  I believe that this PR finishes the job.  The reimplementations I pulled in are *mostly* equivalent, although not always  i.e. in the case of  `singularize`.  I think that should be ok though, we don't actually need compatibility with activesupport.