### PR TITLE
Add convenience methods for smart enum

### DIFF
--- a/lib/smart_enum/active_record_compatibility.rb
+++ b/lib/smart_enum/active_record_compatibility.rb
@@ -105,6 +105,26 @@ class SmartEnum
         values
       end
 
+      def first(num=nil)
+        if num
+          values.first(num)
+        else
+          values.first
+        end
+      end
+
+      def last(num=nil)
+        if num
+          values.last(num)
+        else
+          values.last
+        end
+      end
+
+      def count
+        values.count
+      end
+
       STRING = [String].freeze
       SYMBOL = [Symbol].freeze
       BOOLEAN = [TrueClass, FalseClass].freeze

--- a/spec/active_record_compatibility_spec.rb
+++ b/spec/active_record_compatibility_spec.rb
@@ -99,6 +99,39 @@ RSpec.describe SmartEnum::ActiveRecordCompatibility do
         end
       end
 
+      describe 'first' do
+        it 'finds the first attribute' do
+          result = model.first
+          expect(result.name).to eq "A"
+        end
+
+        it 'can grab the first N elements' do
+          results = model.first(2)
+          expect(results.first.name).to eq "A"
+          expect(results.last.name).to eq "B"
+        end
+      end
+
+      describe 'last' do
+        it 'finds the last attribute' do
+          result = model.last
+          expect(result.name).to eq "C"
+        end
+
+        it 'can grab the last N elements' do
+          results = model.last(2)
+          expect(results.first.name).to eq "B"
+          expect(results.last.name).to eq "C"
+        end
+      end
+
+      describe 'count' do
+        it 'returns the count of objects' do
+          count = model.count
+          expect(count).to eq(3)
+        end
+      end
+
       describe 'find' do
         it 'finds using PK only' do
           result = model.find(1)


### PR DESCRIPTION
In a lot of Ruby enums it is idiomatic to respond to first, last, and
count. I found myself reaching for these a lot with smart_enum when
working in the console and not having them annoyed me. Therefore I added
them and added some specs for them.