### PR TITLE
YamlStore supports loading values from multiples files in a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+bundle
 /.yardoc
 /_yardoc/
 /coverage/

--- a/lib/smart_enum/yaml_store.rb
+++ b/lib/smart_enum/yaml_store.rb
@@ -4,6 +4,12 @@ require 'yaml'
 # Methods for registering values from YAML files
 class SmartEnum
   module YamlStore
+    # Loads values from a YAML file or files
+    #
+    # Looks for a file or directory named after the enum type in the data root.
+    # If a directory is found, values from all of the YAML files in that directory
+    # are loaded.
+    # Otherwise, values are loaded from the file named after the enum.
     def register_values_from_file!
       unless SmartEnum::YamlStore.data_root
         raise "Must set SmartEnum::YamlStore.data_root before using `register_values_from_file!`"
@@ -12,10 +18,17 @@ class SmartEnum
         raise "Cannot infer data file for anonymous class"
       end
 
-      filename = "#{SmartEnum::Utilities.tableize(self.name)}.yml"
-      file_path = File.join(SmartEnum::YamlStore.data_root, filename)
-      values = YAML.load_file(file_path)
-      register_values(values, self, detect_sti_types: true)
+      basename = SmartEnum::Utilities.tableize(self.name)
+      dirname = File.join(SmartEnum::YamlStore.data_root, basename)
+      files = if Dir.exists?(dirname)
+                Dir[File.join(dirname, "*.yml")]
+              else
+                [File.join(SmartEnum::YamlStore.data_root, "#{basename}.yml")]
+              end
+      files.each do |file_path|
+        values = YAML.load_file(file_path)
+        register_values(values, self, detect_sti_types: true)
+      end
     end
 
     def self.data_root

--- a/spec/data/bars/evens.yml
+++ b/spec/data/bars/evens.yml
@@ -1,0 +1,5 @@
+---
+- id: 2
+  name: second
+- id: 4
+  name: fourth

--- a/spec/data/bars/odds.yml
+++ b/spec/data/bars/odds.yml
@@ -1,0 +1,5 @@
+---
+- id: 3
+  name: third
+- id: 1
+  name: first

--- a/spec/yaml_store_spec.rb
+++ b/spec/yaml_store_spec.rb
@@ -33,4 +33,20 @@ RSpec.describe SmartEnum::YamlStore do
       expect(Foo.enum_locked?).to be_truthy
     end
   end
+
+  it 'creates new values of the enum for each set of attributes defined in files in inferried directory' do
+      stub_const("Bar", Class.new(SmartEnum){
+        attribute :id, Integer
+        attribute :name, String
+      })
+
+      Bar.register_values_from_file!
+
+      expect(Bar.values.length).to eq(4)
+      expect(Bar[1].name).to eq("first")
+      expect(Bar[2].name).to eq("second")
+      expect(Bar[3].name).to eq("third")
+      expect(Bar[4].name).to eq("fourth")
+
+  end
 end


### PR DESCRIPTION
Some enum types can have a lot of values, and the values have logical
groupings. It can make them easier to manage if the logically grouped
values are stored in their own files. This adds support for storing
values across multiple files in a directory named after the enum type.

The original behavior of loading from a single file still works.