### PR TITLE
Add to README about validating data

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Vehicle.all.map {|v| [v.display_name, v.requires_commercial_license?]}
 ### Validating data in SmartEnum
 
 Currently there is no built in way to validate the data in SmartEnum.
-The pattern that we suggest is to add a small spec to your CI process to
+The pattern that we suggest is to add an automated test to
 validate that the data in SmartEnum models matches what the business logic
 requires.
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ Vehicle.all.map {|v| [v.display_name, v.requires_commercial_license?]}
 # => [["Toyota Camry", false], ["Freightliner Cascadia", true]]
 ```
 
+### Validating data in SmartEnum
+
+Currently there is no built in way to validate the data in SmartEnum.
+The pattern that we suggest is to add a small spec to your CI process to
+validate that the data in SmartEnum models matches what the business logic
+requires.
+
 
 ## Development
 


### PR DESCRIPTION
I ran across some use cases where I wanted to validate data. We discussed it and decided that a lightweight spec was the best solution at the present time.

If we later do built in validations we can remove this part of the README.